### PR TITLE
Retain absolute position for image container

### DIFF
--- a/js/jquery.blImageCenter.js
+++ b/js/jquery.blImageCenter.js
@@ -22,7 +22,7 @@ $.fn.centerImage = function(method, callback) {
     // parent CSS should be in stylesheet, but to reinforce:
     $div.css({
       overflow: 'hidden',
-      position: 'relative'
+      position: $div.css('position') == 'absolute' ? 'absolute' : 'relative'
     });
 
     // temporarily set the image size naturally so we can get the aspect ratio


### PR DESCRIPTION
Image container is set to 'position:relative' in order to absolutely position the image relative to the container. If the image container is previously set to 'position:absolute', the plugin still changes the position to 'relative'.
